### PR TITLE
Improved comments

### DIFF
--- a/sysopt/block.py
+++ b/sysopt/block.py
@@ -370,7 +370,7 @@ class Composite(ComponentBase):  # noqa
                 if src.parent not in valid_components:
                     raise InvalidWire('Failed to add wires:'
                                       f'source component {src.parent} '
-                                      f'not found for wire {pair}' 
+                                      f'not found for wire {pair}'
                                       f'Error arises in composite {self}')
                 if dest.parent not in valid_components:
                     raise InvalidWire('Failed to add wires:'

--- a/sysopt/block.py
+++ b/sysopt/block.py
@@ -308,10 +308,14 @@ class ConnectionList(list):
             dest.size = src.size
         elif not src.size and not dest.size:
             raise ConnectionError(f'Cannot connect {src} to {dest}, '
-                                  f'both have unknown dimensions')
+                                  f'both have unknown dimensions. '
+                                  f'Error occurs in Composite {self._parent()} '
+                                  f'when connecting blocks {src.parent} to {dest.parent}')
         elif src.size != dest.size:
             raise ConnectionError(f'Cannot connect {src} to {dest}, '
-                                  f'incompatible dimensions')
+                                  f'incompatible dimensions. '
+                                  f'Error occurs in Composite {self._parent()} '
+                                  f'when connecting blocks {src.parent} to {dest.parent}, ')
         self.append((src, dest))
 
 
@@ -364,11 +368,13 @@ class Composite(ComponentBase):  # noqa
                 if src.parent not in valid_components:
                     raise InvalidWire('Failed to add wires:'
                                       f'source component {src.parent} '
-                                      f'not found for wire {value}')
+                                      f'not found for wire {pair}' 
+                                      f'Error arises in composite {self}')
                 if dest.parent not in valid_components:
                     raise InvalidWire('Failed to add wires:'
                                       f'Sink component {dest.parent} '
-                                      f'not found for wire {value}')
+                                      f'not found for wire {pair}'
+                                      f'Error arises in composite {self}')
                 self._wires.add(pair)
         elif value is self._wires:
             return

--- a/sysopt/block.py
+++ b/sysopt/block.py
@@ -307,15 +307,17 @@ class ConnectionList(list):
         elif not dest.size and src.size:
             dest.size = src.size
         elif not src.size and not dest.size:
-            raise ConnectionError(f'Cannot connect {src} to {dest}, '
-                                  f'both have unknown dimensions. '
-                                  f'Error occurs in Composite {self._parent()} '
-                                  f'when connecting blocks {src.parent} to {dest.parent}')
+            raise ConnectionError(
+              f'Cannot connect {src} to {dest}, '
+              f'both have unknown dimensions. '
+              f'Error occurs in Composite {self._parent()} '
+              f'when connecting blocks {src.parent} to {dest.parent}.')
         elif src.size != dest.size:
-            raise ConnectionError(f'Cannot connect {src} to {dest}, '
-                                  f'incompatible dimensions. '
-                                  f'Error occurs in Composite {self._parent()} '
-                                  f'when connecting blocks {src.parent} to {dest.parent}, ')
+            raise ConnectionError(
+              f'Cannot connect {src} to {dest}, '
+              f'incompatible dimensions. '
+              f'Error occurs in Composite {self._parent()} '
+              f'when connecting blocks {src.parent} to {dest.parent}.')
         self.append((src, dest))
 
 

--- a/sysopt/blocks/block_operations.py
+++ b/sysopt/blocks/block_operations.py
@@ -240,14 +240,24 @@ class ArgPermute(FunctionOp):
 
     def __call__(self, t, x, z, u, p):
         # This is the input vector that the internal components see
-        u_inner = [
-            z[self.constraint_to_input[i]] if i in self.constraint_to_input
-            else u[self.input_to_input[i]]
-            for i in range(self.codomain.inputs)
-        ]
+        try:
+            u_inner = [
+                z[self.constraint_to_input[i]] if i in self.constraint_to_input
+                else u[self.input_to_input[i]]
+                for i in range(self.codomain.inputs)
+            ]
+            z_inner = z[:self.codomain.constraints]
+            return t, x, z_inner, u_inner, p
 
-        z_inner = z[:self.codomain.constraints]
-        return t, x, z_inner, u_inner, p
+        except:
+            raise Exception(
+                  'Error occurred while connecting wires inside a composite\n' +
+                   f'Current Co-domain: {self.codomain} \n' +
+                   f'Number of inputs: {self.codomain.inputs} \n' +
+                   f'input->input dict: {self.input_to_input} \n' +
+                   f'constraint->input dict: {self.constraint_to_input} \n' +
+                   f'inputs: {u} \n' +
+                   f'constraints: {z}')
 
 
 def _create_functions_from_leaf_block(block: Block):


### PR DESCRIPTION
The first commit adds two new functions to Composite.
print_hierarchy() - prints a text based hierarchy. Shows how everything is connected. 
print_wiring() - uses same hierarchy as above and prints wiring connections.

Second commit adds some extra error reporting when wires are connected inside a codomain. 
This may be obsolete once current bugs are addressed. 

A suggestion for a future improvement would be to add "labels" to Block and Composite instances. This would allow hierarchy/wiring diagrams to be created using the human readable labels rather than names more suitable for computer indexing.
 