### PR TITLE
Fixed bug SYS-93

### DIFF
--- a/sysopt/exceptions.py
+++ b/sysopt/exceptions.py
@@ -1,4 +1,5 @@
 """Exceptions and Error reporting objects."""
+from typing import Tuple
 
 
 class DanglingInputError(ValueError):
@@ -31,7 +32,7 @@ class InvalidComponentError(ValueError):
 
 class UnconnectedOutputError(ValueError):
     def __init__(self, component, channel):
-        message = f'{component} has output ports without no sources:'
+        message = f'Composite {component} has output ports without no sources:'
         message += ','.join(list(str(c) for c in channel))
         super().__init__(message)
 
@@ -52,6 +53,20 @@ class InvalidShape(ValueError):
 
 class EvaluationError(ValueError):
     def __init__(self, graph, context, path, exception):
-        message = f'''{exception} was raised during the evalution of an
+        message = f'''{exception} was raised during the evaluation of an
         expression graph.\n Evaluation order: {path} with context {context}'''
+        super().__init__(message)
+
+
+class InternalWireNotFound(Exception):
+    def __init__(self, wire: Tuple, *args):
+        message = f'Failed to connect {str(wire[0])} -> {str(wire[1])}.'
+        super().__init__(message, *args)
+
+
+class NoTopLevelOutputs(Exception):
+    def __init__(self, root):
+        message = f'Top level model {root} has no defined outputs. You need ' \
+                  f'to wire some from internal components to have any ' \
+                  f'observables.'
         super().__init__(message)

--- a/sysopt/problems/canonical_transform.py
+++ b/sysopt/problems/canonical_transform.py
@@ -1,7 +1,7 @@
 """Symbol Database for simulation and optimisation."""
 # pylint: disable=invalid-name
 import copy
-import warnings
+from warnings import warn
 from typing import Optional, List, Union, Callable, Dict, Tuple, Iterable
 from dataclasses import dataclass, asdict
 from collections import deque
@@ -15,7 +15,7 @@ from sysopt.symbolic import (
     restriction_map, as_array, sparse_matrix, Matrix
 )
 from sysopt.problems.problem_data import FlattenedSystem
-from warnings import warn
+
 from sysopt import warnings
 from sysopt import exceptions
 

--- a/sysopt/warnings.py
+++ b/sysopt/warnings.py
@@ -1,0 +1,9 @@
+"""Sysopt Warning Messages"""
+
+
+class UnconnectedInput(Warning):
+    def __init__(self, wire):
+
+        msg = f'Skipping wire {str(wire[0])} -> {str(wire[1])} as ' \
+              f'input {wire[1]} has not been forwarded to any components.'
+        super().__init__(msg)

--- a/tests/2_solver_interface/test_integrator.py
+++ b/tests/2_solver_interface/test_integrator.py
@@ -120,8 +120,3 @@ class TestSymbolicIntegrator:
 
             expected = block.pushforward(t, params, dparams)
             assert abs(result[0][0] - expected) < 1e-2
-
-
-
-
-


### PR DESCRIPTION
This pull request adds some new exceptions and a warning to address some issues that @ingojahn found when trying to wire up nested composite components with only partially defined internals.

The test case example shows what was reported.
Here, a inner composite with 2 inputs (one of which is unconnected), is then placed inside an outer composite along side a constants vector source which feeds the inner composite inputs.

As written, this should throw a warning and an error.
An exception should be thrown since the top level composite has no outputs (If i can't measure it, it doesn't exist.)
A warning should be thrown since an output is connected to an input that feeds nothing. 

