### PR TITLE
Test module fixes

### DIFF
--- a/tests/1_canonical_xform/test_canonical_xform.py
+++ b/tests/1_canonical_xform/test_canonical_xform.py
@@ -11,6 +11,7 @@ from sysopt.problems.wiring_tables import (
 from sysopt.blocks.common import Gain, LowPassFilter, Oscillator
 from sysopt import exceptions
 from dataclasses import asdict
+from sysopt.backends.casadi import codesign_solver
 
 from tests.mocks import LinearScalarEquation
 md = Metadata(

--- a/tests/8_codesign_test_problems/test_problem_1.py
+++ b/tests/8_codesign_test_problems/test_problem_1.py
@@ -10,6 +10,7 @@ from sysopt.modelling.builders import FullStateOutput
 from sysopt.blocks import ConstantSignal, Gain
 from sysopt import Composite, Metadata, PiecewiseConstantSignal, Variable
 from sysopt.problems import SolverContext
+from sysopt.backends.casadi import codesign_solver
 
 
 def dxdt(t, x, u, p):

--- a/tests/8_codesign_test_problems/test_problem_2.py
+++ b/tests/8_codesign_test_problems/test_problem_2.py
@@ -12,6 +12,7 @@ from sysopt.blocks import ConstantSignal
 from sysopt import Metadata, Composite
 from sysopt.symbolic import Variable, PiecewiseConstantSignal
 from sysopt.problems import SolverContext
+from sysopt.backends.casadi import codesign_solver
 
 
 def dxdt(t, x, u, p):

--- a/tests/8_codesign_test_problems/test_problem_3.py
+++ b/tests/8_codesign_test_problems/test_problem_3.py
@@ -13,6 +13,7 @@ from sysopt.problems import SolverContext
 from sysopt.modelling.builders import FullStateOutput
 from sysopt.blocks import ConstantSignal
 from sysopt.symbolic import PiecewiseConstantSignal, Variable
+from sysopt.backends.casadi import codesign_solver
 
 J = 1
 


### PR DESCRIPTION
Test modules relied on imports from preceeding tests and needed to be
executed in order. Fixed so that test modules pass when executed
individually.
